### PR TITLE
Add Tkinter GUI with configuration persistence

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "default_output_dir": "summaries"
+}

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,43 @@
+"""Configuration utilities for the video transcription summary GUI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "config.json"
+DEFAULT_OUTPUT_DIR = (Path(__file__).resolve().parent.parent / "summaries").resolve()
+
+
+def load_config() -> dict:
+    """Load configuration from CONFIG_PATH.
+
+    Returns an empty dict if the file does not exist or is invalid.
+    """
+    if CONFIG_PATH.exists():
+        try:
+            with CONFIG_PATH.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def save_config(config: dict) -> None:
+    """Persist configuration to CONFIG_PATH."""
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with CONFIG_PATH.open("w", encoding="utf-8") as f:
+        json.dump(config, f, indent=2)
+
+
+def get_default_output_dir() -> str:
+    """Retrieve the default output directory from config or fallback."""
+    config = load_config()
+    return config.get("default_output_dir", str(DEFAULT_OUTPUT_DIR))
+
+
+def set_default_output_dir(path: str) -> None:
+    """Persist a new default output directory to the config file."""
+    config = load_config()
+    config["default_output_dir"] = path
+    save_config(config)
+

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,0 +1,68 @@
+"""Tkinter-based GUI for configuring and running video transcription summaries."""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog
+
+from config import get_default_output_dir, set_default_output_dir
+from process import process_video
+
+
+def browse_output_dir() -> None:
+    """Open a directory chooser and update the output directory selection."""
+    path = filedialog.askdirectory(initialdir=output_dir_var.get())
+    if path:
+        output_dir_var.set(path)
+        set_default_output_dir(path)
+
+
+def run() -> None:
+    """Invoke the main processing function with the provided parameters."""
+    process_video(
+        url_var.get(),
+        language_var.get(),
+        output_dir_var.get(),
+        model_var.get(),
+        prompt_var.get(),
+    )
+    set_default_output_dir(output_dir_var.get())
+
+
+root = tk.Tk()
+root.title("Video Transcription Summary")
+
+# URL field
+url_var = tk.StringVar()
+tk.Label(root, text="Video URL:").grid(row=0, column=0, sticky="e")
+tk.Entry(root, textvariable=url_var, width=50).grid(row=0, column=1, padx=5, pady=5)
+
+# Language dropdown
+languages = ["English", "Spanish", "French", "German"]
+language_var = tk.StringVar(value=languages[0])
+tk.Label(root, text="Language:").grid(row=1, column=0, sticky="e")
+tk.OptionMenu(root, language_var, *languages).grid(row=1, column=1, padx=5, pady=5, sticky="w")
+
+# Output folder selector
+output_dir_var = tk.StringVar(value=get_default_output_dir())
+tk.Label(root, text="Output Folder:").grid(row=2, column=0, sticky="e")
+tk.Entry(root, textvariable=output_dir_var, width=40).grid(row=2, column=1, padx=5, pady=5, sticky="w")
+tk.Button(root, text="Browse", command=browse_output_dir).grid(row=2, column=2, padx=5, pady=5)
+
+# ChatGPT model
+model_var = tk.StringVar(value="gpt-3.5-turbo")
+tk.Label(root, text="ChatGPT Model:").grid(row=3, column=0, sticky="e")
+tk.Entry(root, textvariable=model_var, width=50).grid(row=3, column=1, padx=5, pady=5)
+
+# Prompt
+prompt_var = tk.StringVar()
+tk.Label(root, text="Prompt:").grid(row=4, column=0, sticky="e")
+tk.Entry(root, textvariable=prompt_var, width=50).grid(row=4, column=1, padx=5, pady=5)
+
+# Run button
+run_button = tk.Button(root, text="Run", command=run)
+run_button.grid(row=5, column=1, pady=10)
+
+
+if __name__ == "__main__":
+    root.mainloop()
+

--- a/src/process.py
+++ b/src/process.py
@@ -1,0 +1,18 @@
+"""Main processing stub for video transcription summary."""
+from __future__ import annotations
+
+
+def process_video(url: str, language: str, output_dir: str, model: str, prompt: str) -> None:
+    """Placeholder function representing the core processing pipeline.
+
+    In a full implementation this would download the video, extract audio,
+    generate transcripts and summaries, etc. For now it simply prints the
+    received parameters so the GUI wiring can be verified.
+    """
+    print("Processing video with parameters:")
+    print(f"URL: {url}")
+    print(f"Language: {language}")
+    print(f"Output Directory: {output_dir}")
+    print(f"ChatGPT Model: {model}")
+    print(f"Prompt: {prompt}")
+


### PR DESCRIPTION
## Summary
- implement Tkinter GUI with fields for video URL, language, output folder, model, and prompt
- add run button wired to processing stub and persist output folder in config
- introduce simple processing stub and config utilities

## Testing
- `pytest`
- `python -m py_compile src/config.py src/process.py src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6978dd5d483238b9235e181a2b66a