### PR TITLE
feat: allow URL or audio file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Video Transcription Summary
 
-This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content.
+This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content. The GUI allows entering a video URL or selecting a local audio file (common formats are converted to WAV so Whisper can process them).
 
 ## Installation
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -5,7 +5,7 @@ import tkinter as tk
 from tkinter import filedialog
 
 from config import get_default_output_dir, set_default_output_dir
-from process import process_video
+from process import process_media
 
 
 def browse_output_dir() -> None:
@@ -16,10 +16,33 @@ def browse_output_dir() -> None:
         set_default_output_dir(path)
 
 
+def browse_audio_file() -> None:
+    """Open a file chooser and update the audio file selection."""
+    path = filedialog.askopenfilename(
+        filetypes=[("Audio Files", "*.mp3 *.wav *.m4a *.flac *.ogg")]
+    )
+    if path:
+        audio_file_var.set(path)
+
+
+def toggle_input_fields() -> None:
+    """Enable fields based on the selected input type."""
+    if input_type_var.get() == "url":
+        url_entry.config(state="normal")
+        audio_entry.config(state="disabled")
+        audio_browse.config(state="disabled")
+    else:
+        url_entry.config(state="disabled")
+        audio_entry.config(state="normal")
+        audio_browse.config(state="normal")
+
+
 def run() -> None:
     """Invoke the main processing function with the provided parameters."""
-    process_video(
-        url_var.get(),
+    source = url_var.get() if input_type_var.get() == "url" else audio_file_var.get()
+    process_media(
+        source,
+        input_type_var.get(),
         language_var.get(),
         output_dir_var.get(),
         model_var.get(),
@@ -31,36 +54,67 @@ def run() -> None:
 root = tk.Tk()
 root.title("Video Transcription Summary")
 
+# Input type selection
+input_type_var = tk.StringVar(value="url")
+tk.Label(root, text="Input Type:").grid(row=0, column=0, sticky="e")
+tk.Radiobutton(
+    root, text="URL", variable=input_type_var, value="url", command=toggle_input_fields
+).grid(row=0, column=1, sticky="w")
+tk.Radiobutton(
+    root,
+    text="Audio File",
+    variable=input_type_var,
+    value="audio",
+    command=toggle_input_fields,
+).grid(row=0, column=2, sticky="w")
+
 # URL field
 url_var = tk.StringVar()
-tk.Label(root, text="Video URL:").grid(row=0, column=0, sticky="e")
-tk.Entry(root, textvariable=url_var, width=50).grid(row=0, column=1, padx=5, pady=5)
+tk.Label(root, text="Video URL:").grid(row=1, column=0, sticky="e")
+url_entry = tk.Entry(root, textvariable=url_var, width=50)
+url_entry.grid(row=1, column=1, padx=5, pady=5)
+
+# Audio file selector
+audio_file_var = tk.StringVar()
+tk.Label(root, text="Audio File:").grid(row=2, column=0, sticky="e")
+audio_entry = tk.Entry(root, textvariable=audio_file_var, width=40)
+audio_entry.grid(row=2, column=1, padx=5, pady=5, sticky="w")
+audio_browse = tk.Button(root, text="Browse", command=browse_audio_file)
+audio_browse.grid(row=2, column=2, padx=5, pady=5)
 
 # Language dropdown
 languages = ["English", "Spanish", "French", "German"]
 language_var = tk.StringVar(value=languages[0])
-tk.Label(root, text="Language:").grid(row=1, column=0, sticky="e")
-tk.OptionMenu(root, language_var, *languages).grid(row=1, column=1, padx=5, pady=5, sticky="w")
+tk.Label(root, text="Language:").grid(row=3, column=0, sticky="e")
+tk.OptionMenu(root, language_var, *languages).grid(
+    row=3, column=1, padx=5, pady=5, sticky="w"
+)
 
 # Output folder selector
 output_dir_var = tk.StringVar(value=get_default_output_dir())
-tk.Label(root, text="Output Folder:").grid(row=2, column=0, sticky="e")
-tk.Entry(root, textvariable=output_dir_var, width=40).grid(row=2, column=1, padx=5, pady=5, sticky="w")
-tk.Button(root, text="Browse", command=browse_output_dir).grid(row=2, column=2, padx=5, pady=5)
+tk.Label(root, text="Output Folder:").grid(row=4, column=0, sticky="e")
+tk.Entry(root, textvariable=output_dir_var, width=40).grid(
+    row=4, column=1, padx=5, pady=5, sticky="w"
+)
+tk.Button(root, text="Browse", command=browse_output_dir).grid(
+    row=4, column=2, padx=5, pady=5
+)
 
 # ChatGPT model
 model_var = tk.StringVar(value="gpt-3.5-turbo")
-tk.Label(root, text="ChatGPT Model:").grid(row=3, column=0, sticky="e")
-tk.Entry(root, textvariable=model_var, width=50).grid(row=3, column=1, padx=5, pady=5)
+tk.Label(root, text="ChatGPT Model:").grid(row=5, column=0, sticky="e")
+tk.Entry(root, textvariable=model_var, width=50).grid(row=5, column=1, padx=5, pady=5)
 
 # Prompt
 prompt_var = tk.StringVar()
-tk.Label(root, text="Prompt:").grid(row=4, column=0, sticky="e")
-tk.Entry(root, textvariable=prompt_var, width=50).grid(row=4, column=1, padx=5, pady=5)
+tk.Label(root, text="Prompt:").grid(row=6, column=0, sticky="e")
+tk.Entry(root, textvariable=prompt_var, width=50).grid(row=6, column=1, padx=5, pady=5)
 
 # Run button
 run_button = tk.Button(root, text="Run", command=run)
-run_button.grid(row=5, column=1, pady=10)
+run_button.grid(row=7, column=1, pady=10)
+
+toggle_input_fields()
 
 
 if __name__ == "__main__":

--- a/src/process.py
+++ b/src/process.py
@@ -1,18 +1,50 @@
-"""Main processing stub for video transcription summary."""
+"""Main processing stub for handling video URLs or local audio files."""
 from __future__ import annotations
 
+from pathlib import Path
+import tempfile
 
-def process_video(url: str, language: str, output_dir: str, model: str, prompt: str) -> None:
+import ffmpeg
+
+
+def _unify_audio_format(audio_path: str) -> str:
+    """Convert an arbitrary audio file to WAV so Whisper can consume it."""
+    temp_wav = Path(tempfile.mkstemp(suffix=".wav")[1])
+    (
+        ffmpeg.input(audio_path)
+        .output(str(temp_wav), format="wav")
+        .overwrite_output()
+        .run(quiet=True)
+    )
+    return str(temp_wav)
+
+
+def process_media(
+    source: str,
+    input_type: str,
+    language: str,
+    output_dir: str,
+    model: str,
+    prompt: str,
+) -> None:
     """Placeholder function representing the core processing pipeline.
 
     In a full implementation this would download the video, extract audio,
     generate transcripts and summaries, etc. For now it simply prints the
-    received parameters so the GUI wiring can be verified.
+    received parameters so the GUI wiring can be verified. If the input is a
+    local audio file it is converted to WAV first so it is compatible with
+    Whisper.
     """
-    print("Processing video with parameters:")
-    print(f"URL: {url}")
+
+    print("Processing media with parameters:")
+    print(f"Source: {source}")
+    print(f"Input Type: {input_type}")
     print(f"Language: {language}")
     print(f"Output Directory: {output_dir}")
     print(f"ChatGPT Model: {model}")
     print(f"Prompt: {prompt}")
+
+    if input_type == "audio":
+        unified = _unify_audio_format(source)
+        print(f"Unified audio file: {unified}")
 


### PR DESCRIPTION
## Summary
- allow choosing a video URL or local audio file in the GUI
- convert arbitrary audio files to WAV before processing
- document audio file support in README

## Testing
- `python -m py_compile src/gui.py src/process.py`


------
https://chatgpt.com/codex/tasks/task_e_68a699695e7c8323a43c4ca19cb074a6