### PR TITLE
Split transcription and summary with responsive GUI

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -1,11 +1,13 @@
-"""Tkinter-based GUI for configuring and running video transcription summaries."""
+"""Tkinter GUI for transcribing audio and generating summaries."""
 from __future__ import annotations
 
+import threading
 import tkinter as tk
+from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
 from config import get_default_output_dir, set_default_output_dir
-from process import process_media
+from process import summarize_transcript, transcribe_media
 
 
 def browse_output_dir() -> None:
@@ -37,120 +39,198 @@ def toggle_input_fields() -> None:
         audio_browse.config(state="normal")
 
 
-def run() -> None:
-    """Invoke the main processing function with the provided parameters."""
+def start_transcription() -> None:
+    """Run the transcription step in a background thread."""
     source = url_var.get() if input_type_var.get() == "url" else audio_file_var.get()
+    if not source:
+        messagebox.showwarning("Missing source", "Please provide a URL or audio file.")
+        return
+
+    transcribe_progress_var.set(0)
+    transcribe_status_var.set("Starting...")
 
     def update_progress(percent: float, status: str | None = None) -> None:
-        progress_var.set(percent)
-        if status is not None:
-            status_var.set(status)
-        root.update_idletasks()
+        def _update() -> None:
+            transcribe_progress_var.set(percent)
+            if status is not None:
+                transcribe_status_var.set(status)
 
-    progress_var.set(0)
-    update_progress(0, "Starting...")
-    try:
-        transcript = process_media(
-            source,
-            input_type_var.get(),
-            language_var.get(),
-            output_dir_var.get(),
-            whisper_model_var.get(),
-            gpt_model_var.get(),
-            prompt_var.get(),
-            progress_callback=update_progress,
-        )
-        status_var.set(f"Completed: {transcript}")
-        progress_var.set(100)
-    except Exception as exc:  # pragma: no cover - GUI error path
-        status_var.set("Error")
-        messagebox.showerror("Error", str(exc))
-    set_default_output_dir(output_dir_var.get())
+        root.after(0, _update)
+
+    def task() -> None:
+        try:
+            path = transcribe_media(
+                source,
+                input_type_var.get(),
+                language_var.get(),
+                output_dir_var.get(),
+                whisper_model_var.get(),
+                progress_callback=update_progress,
+            )
+            transcript_path_var.set(path)
+            text = Path(path).read_text(encoding="utf-8")
+            root.after(0, lambda: transcript_text.delete("1.0", tk.END))
+            root.after(0, lambda: transcript_text.insert(tk.END, text))
+            root.after(0, lambda: transcribe_status_var.set(f"Saved transcript: {path}"))
+        except Exception as exc:  # pragma: no cover - GUI error path
+            root.after(0, lambda: transcribe_status_var.set("Error"))
+            root.after(0, lambda: messagebox.showerror("Error", str(exc)))
+        finally:
+            set_default_output_dir(output_dir_var.get())
+
+    threading.Thread(target=task, daemon=True).start()
+
+
+def start_summary() -> None:
+    """Run the ChatGPT summarisation in a background thread."""
+    path = transcript_path_var.get()
+    if not path:
+        messagebox.showwarning("No transcript", "Run transcription first.")
+        return
+
+    Path(path).write_text(transcript_text.get("1.0", tk.END).strip(), encoding="utf-8")
+    summary_progress_var.set(0)
+    summary_status_var.set("Starting...")
+
+    def update_progress(percent: float, status: str | None = None) -> None:
+        def _update() -> None:
+            summary_progress_var.set(percent)
+            if status is not None:
+                summary_status_var.set(status)
+
+        root.after(0, _update)
+
+    def task() -> None:
+        try:
+            summary_path = summarize_transcript(
+                path,
+                gpt_model_var.get(),
+                prompt_var.get(),
+                progress_callback=update_progress,
+            )
+            text = Path(summary_path).read_text(encoding="utf-8")
+            root.after(0, lambda: summary_output.delete("1.0", tk.END))
+            root.after(0, lambda: summary_output.insert(tk.END, text))
+            root.after(0, lambda: summary_status_var.set(f"Saved summary: {summary_path}"))
+        except Exception as exc:  # pragma: no cover - GUI error path
+            root.after(0, lambda: summary_status_var.set("Error"))
+            root.after(0, lambda: messagebox.showerror("Error", str(exc)))
+
+    threading.Thread(target=task, daemon=True).start()
 
 
 root = tk.Tk()
 root.title("Video Transcription Summary")
 
-# Input type selection
+# ---------------- Transcription section ----------------
+transcribe_frame = tk.LabelFrame(root, text="Audio Transcription")
+transcribe_frame.pack(fill="x", padx=10, pady=5)
+
 input_type_var = tk.StringVar(value="url")
-tk.Label(root, text="Input Type:").grid(row=0, column=0, sticky="e")
+tk.Label(transcribe_frame, text="Input Type:").grid(row=0, column=0, sticky="e")
 tk.Radiobutton(
-    root, text="URL", variable=input_type_var, value="url", command=toggle_input_fields
+    transcribe_frame,
+    text="URL",
+    variable=input_type_var,
+    value="url",
+    command=toggle_input_fields,
 ).grid(row=0, column=1, sticky="w")
 tk.Radiobutton(
-    root,
+    transcribe_frame,
     text="Audio File",
     variable=input_type_var,
     value="audio",
     command=toggle_input_fields,
 ).grid(row=0, column=2, sticky="w")
 
-# URL field
 url_var = tk.StringVar()
-tk.Label(root, text="Video URL:").grid(row=1, column=0, sticky="e")
-url_entry = tk.Entry(root, textvariable=url_var, width=50)
-url_entry.grid(row=1, column=1, padx=5, pady=5)
+tk.Label(transcribe_frame, text="Video URL:").grid(row=1, column=0, sticky="e")
+url_entry = tk.Entry(transcribe_frame, textvariable=url_var, width=50)
+url_entry.grid(row=1, column=1, padx=5, pady=2, columnspan=2, sticky="w")
 
-# Audio file selector
 audio_file_var = tk.StringVar()
-tk.Label(root, text="Audio File:").grid(row=2, column=0, sticky="e")
-audio_entry = tk.Entry(root, textvariable=audio_file_var, width=40)
-audio_entry.grid(row=2, column=1, padx=5, pady=5, sticky="w")
-audio_browse = tk.Button(root, text="Browse", command=browse_audio_file)
-audio_browse.grid(row=2, column=2, padx=5, pady=5)
+tk.Label(transcribe_frame, text="Audio File:").grid(row=2, column=0, sticky="e")
+audio_entry = tk.Entry(transcribe_frame, textvariable=audio_file_var, width=40)
+audio_entry.grid(row=2, column=1, padx=5, pady=2, sticky="w")
+audio_browse = tk.Button(transcribe_frame, text="Browse", command=browse_audio_file)
+audio_browse.grid(row=2, column=2, padx=5, pady=2)
 
-# Language dropdown
 languages = ["English", "中文", "日本語", "Deutsch"]
 language_var = tk.StringVar(value=languages[0])
-tk.Label(root, text="Language:").grid(row=3, column=0, sticky="e")
-tk.OptionMenu(root, language_var, *languages).grid(
-    row=3, column=1, padx=5, pady=5, sticky="w"
+tk.Label(transcribe_frame, text="Language:").grid(row=3, column=0, sticky="e")
+tk.OptionMenu(transcribe_frame, language_var, *languages).grid(
+    row=3, column=1, padx=5, pady=2, sticky="w"
 )
 
-# Output folder selector
 output_dir_var = tk.StringVar(value=get_default_output_dir())
-tk.Label(root, text="Output Folder:").grid(row=4, column=0, sticky="e")
-tk.Entry(root, textvariable=output_dir_var, width=40).grid(
-    row=4, column=1, padx=5, pady=5, sticky="w"
+tk.Label(transcribe_frame, text="Output Folder:").grid(row=4, column=0, sticky="e")
+tk.Entry(transcribe_frame, textvariable=output_dir_var, width=40).grid(
+    row=4, column=1, padx=5, pady=2, sticky="w"
 )
-tk.Button(root, text="Browse", command=browse_output_dir).grid(
-    row=4, column=2, padx=5, pady=5
+tk.Button(transcribe_frame, text="Browse", command=browse_output_dir).grid(
+    row=4, column=2, padx=5, pady=2
 )
 
-# Whisper model dropdown
 whisper_models = ["tiny", "base", "small", "medium", "large"]
 whisper_model_var = tk.StringVar(value="small")
-tk.Label(root, text="Whisper Model:").grid(row=5, column=0, sticky="e")
-tk.OptionMenu(root, whisper_model_var, *whisper_models).grid(
-    row=5, column=1, padx=5, pady=5, sticky="w"
+tk.Label(transcribe_frame, text="Whisper Model:").grid(row=5, column=0, sticky="e")
+tk.OptionMenu(transcribe_frame, whisper_model_var, *whisper_models).grid(
+    row=5, column=1, padx=5, pady=2, sticky="w"
 )
 
-# ChatGPT model
+transcribe_button = tk.Button(transcribe_frame, text="Transcribe", command=start_transcription)
+transcribe_button.grid(row=6, column=1, pady=5)
+
+transcribe_progress_var = tk.DoubleVar(value=0)
+ttk.Progressbar(transcribe_frame, variable=transcribe_progress_var, maximum=100).grid(
+    row=7, column=0, columnspan=3, padx=5, pady=2, sticky="we"
+)
+
+transcribe_status_var = tk.StringVar(value="")
+tk.Label(transcribe_frame, textvariable=transcribe_status_var).grid(
+    row=8, column=0, columnspan=3
+)
+
+# ---------------- Summary section ----------------
+summary_frame = tk.LabelFrame(root, text="ChatGPT Summary")
+summary_frame.pack(fill="both", expand=True, padx=10, pady=5)
+
 gpt_model_var = tk.StringVar(value="gpt-3.5-turbo")
-tk.Label(root, text="ChatGPT Model:").grid(row=6, column=0, sticky="e")
-tk.Entry(root, textvariable=gpt_model_var, width=50).grid(row=6, column=1, padx=5, pady=5)
-
-# Prompt
-prompt_var = tk.StringVar()
-tk.Label(root, text="Prompt:").grid(row=7, column=0, sticky="e")
-tk.Entry(root, textvariable=prompt_var, width=50).grid(row=7, column=1, padx=5, pady=5)
-
-# Run button
-run_button = tk.Button(root, text="Run", command=run)
-run_button.grid(row=8, column=1, pady=10)
-
-# Progress bar
-progress_var = tk.DoubleVar(value=0)
-ttk.Progressbar(root, variable=progress_var, maximum=100).grid(
-    row=9, column=0, columnspan=3, padx=5, pady=5, sticky="we"
+tk.Label(summary_frame, text="ChatGPT Model:").grid(row=0, column=0, sticky="e")
+tk.Entry(summary_frame, textvariable=gpt_model_var, width=40).grid(
+    row=0, column=1, padx=5, pady=2, sticky="w"
 )
 
-# Status label
-status_var = tk.StringVar(value="")
-tk.Label(root, textvariable=status_var).grid(row=10, column=1, pady=5)
+prompt_var = tk.StringVar()
+tk.Label(summary_frame, text="Prompt:").grid(row=1, column=0, sticky="e")
+tk.Entry(summary_frame, textvariable=prompt_var, width=40).grid(
+    row=1, column=1, padx=5, pady=2, sticky="w"
+)
+
+tk.Label(summary_frame, text="Transcript:").grid(row=2, column=0, sticky="ne")
+transcript_text = tk.Text(summary_frame, height=8, width=60)
+transcript_text.grid(row=2, column=1, padx=5, pady=2)
+
+tk.Label(summary_frame, text="Summary:").grid(row=3, column=0, sticky="ne")
+summary_output = tk.Text(summary_frame, height=8, width=60)
+summary_output.grid(row=3, column=1, padx=5, pady=2)
+
+summarize_button = tk.Button(summary_frame, text="Summarize", command=start_summary)
+summarize_button.grid(row=4, column=1, pady=5)
+
+summary_progress_var = tk.DoubleVar(value=0)
+ttk.Progressbar(summary_frame, variable=summary_progress_var, maximum=100).grid(
+    row=5, column=0, columnspan=2, padx=5, pady=2, sticky="we"
+)
+
+summary_status_var = tk.StringVar(value="")
+tk.Label(summary_frame, textvariable=summary_status_var).grid(
+    row=6, column=0, columnspan=2
+)
+
+transcript_path_var = tk.StringVar(value="")
 
 toggle_input_fields()
-
 
 if __name__ == "__main__":
     root.mainloop()


### PR DESCRIPTION
## Summary
- Add separate `transcribe_media` and `summarize_transcript` helpers.
- Redesign Tkinter UI into transcription and ChatGPT sections with individual start buttons.
- Run long operations in background threads and update progress bars for a responsive interface.

## Testing
- `pytest -q`
- `python -m py_compile src/process.py src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6b2b0f8fc8323bd7d278901f630e8