### PR TITLE
Fix NameError in Tkinter error handling

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -73,8 +73,9 @@ def start_transcription() -> None:
             root.after(0, lambda: transcript_text.insert(tk.END, text))
             root.after(0, lambda: transcribe_status_var.set(f"Saved transcript: {path}"))
         except Exception as exc:  # pragma: no cover - GUI error path
+            error_message = str(exc)
             root.after(0, lambda: transcribe_status_var.set("Error"))
-            root.after(0, lambda: messagebox.showerror("Error", str(exc)))
+            root.after(0, lambda msg=error_message: messagebox.showerror("Error", msg))
         finally:
             set_default_output_dir(output_dir_var.get())
 
@@ -113,8 +114,9 @@ def start_summary() -> None:
             root.after(0, lambda: summary_output.insert(tk.END, text))
             root.after(0, lambda: summary_status_var.set(f"Saved summary: {summary_path}"))
         except Exception as exc:  # pragma: no cover - GUI error path
+            error_message = str(exc)
             root.after(0, lambda: summary_status_var.set("Error"))
-            root.after(0, lambda: messagebox.showerror("Error", str(exc)))
+            root.after(0, lambda msg=error_message: messagebox.showerror("Error", msg))
 
     threading.Thread(target=task, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- capture exception messages before scheduling GUI updates to prevent NameError
- apply fix for both transcription and summary threads

## Testing
- `python -m py_compile src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7aeabdd1883238ec62a6b5e486bd1