### PR TITLE
Fix encoding error and add batch transcription queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Video Transcription Summary
 
-This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content. The GUI allows entering a video URL or selecting a local audio file (common formats are converted to WAV so Whisper can process them).
+This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content. The GUI allows entering one or more video URLs or selecting multiple local audio files (common formats are converted to WAV so Whisper can process them). Each source is transcribed in sequence and written to its own transcript file.
 
 Audio shorter than 15 minutes is transcribed directly. Longer media is split into equal parts of up to 15 minutes each before transcription, and the resulting text is concatenated.
 


### PR DESCRIPTION
## Summary
- fix Windows decoding failures by forcing UTF-8 in ffmpeg/ffprobe subprocess calls
- add `transcribe_batch` helper and GUI support for processing multiple URLs or audio files sequentially
- document batch transcription in README

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7b62889f0832395dc7c7fff01d638