### PR TITLE
Add Windows batch launcher for GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,12 @@ Audio shorter than 15 minutes is transcribed directly. Longer media is split int
    ```
    The application reads these values using [python-dotenv](https://github.com/theskumar/python-dotenv).
 
+
+## Windows Launcher
+
+After creating a virtual environment named `venv` and installing the project dependencies, you can start the GUI without using the command line:
+
+1. Double-click `run_gui.bat` in the project folder.
+2. The script activates `venv` and launches `src\gui.py` using `pythonw`, so no console window appears.
+3. If `venv` is missing, the script displays instructions for creating it.
+

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Launch Video Transcription Summary GUI inside its virtual environment.
+REM Ensure a virtual environment exists at venv\.
+
+SET SCRIPT_DIR=%~dp0
+SET VENV_DIR=%SCRIPT_DIR%venv
+
+IF NOT EXIST "%VENV_DIR%\Scripts\activate.bat" (
+    echo Virtual environment not found in %VENV_DIR%.
+    echo Create it with: python -m venv venv ^&^& pip install -r requirements.txt
+    pause
+    exit /b 1
+)
+
+CALL "%VENV_DIR%\Scripts\activate.bat"
+cd /d "%SCRIPT_DIR%"
+pythonw src\gui.py


### PR DESCRIPTION
## Summary
- add `run_gui.bat` for double-click GUI launch in Windows virtual environment
- document Windows launcher usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f20f6c88323acd33cb38c5a980b