### PR TITLE
Support Conda environment in Windows launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Audio shorter than 15 minutes is transcribed directly. Longer media is split int
 
 ## Windows Launcher
 
-After creating a virtual environment named `venv` and installing the project dependencies, you can start the GUI without using the command line:
+The `run_gui.bat` script can launch the GUI without manually activating an environment:
 
-1. Double-click `run_gui.bat` in the project folder.
-2. The script activates `venv` and launches `src\gui.py` using `pythonw`, so no console window appears.
-3. If `venv` is missing, the script displays instructions for creating it.
+1. If a Conda environment is already active, it is used.
+2. Otherwise the script tries to run via a Conda environment named `VTS` (change `CONDA_ENV_NAME` in the script to use a different name).
+3. If Conda is unavailable, it falls back to a local `venv` if one exists.
 
+Double-click `run_gui.bat` in the project folder. The script runs `src\gui.py` with `pythonw`, so no console window appears. If no suitable environment is found, it displays instructions for creating one.

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,17 +1,38 @@
 @echo off
-REM Launch Video Transcription Summary GUI inside its virtual environment.
-REM Ensure a virtual environment exists at venv\.
+REM Launch Video Transcription Summary GUI from a Python environment.
+REM 1) Use an active Conda environment if one is already enabled.
+REM 2) Otherwise try to run via a named Conda environment.
+REM 3) Finally fall back to a local venv.
 
 SET SCRIPT_DIR=%~dp0
 SET VENV_DIR=%SCRIPT_DIR%venv
+SET CONDA_ENV_NAME=VTS
 
-IF NOT EXIST "%VENV_DIR%\Scripts\activate.bat" (
-    echo Virtual environment not found in %VENV_DIR%.
-    echo Create it with: python -m venv venv ^&^& pip install -r requirements.txt
-    pause
-    exit /b 1
+REM If already running inside a Conda environment, just execute the app.
+IF NOT "%CONDA_PREFIX%"=="" (
+    cd /d "%SCRIPT_DIR%"
+    pythonw src\gui.py
+    exit /b 0
 )
 
-CALL "%VENV_DIR%\Scripts\activate.bat"
-cd /d "%SCRIPT_DIR%"
-pythonw src\gui.py
+REM Try launching with conda run and a named environment.
+where conda >NUL 2>&1
+IF %ERRORLEVEL%==0 (
+    cd /d "%SCRIPT_DIR%"
+    conda run -n %CONDA_ENV_NAME% pythonw src\gui.py
+    IF %ERRORLEVEL%==0 exit /b 0
+)
+
+REM If a local venv exists, activate it.
+IF EXIST "%VENV_DIR%\Scripts\activate.bat" (
+    CALL "%VENV_DIR%\Scripts\activate.bat"
+    cd /d "%SCRIPT_DIR%"
+    pythonw src\gui.py
+    exit /b 0
+)
+
+echo No Python environment found.
+echo Install dependencies with Conda (conda create -n %CONDA_ENV_NAME% -f requirements.txt) or:
+echo     python -m venv venv ^&^& pip install -r requirements.txt
+pause
+exit /b 1


### PR DESCRIPTION
## Summary
- Allow `run_gui.bat` to auto-launch the GUI via a named Conda environment or fallback to a local `venv`
- Update README Windows instructions to mention automatic environment selection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca035ee188323b9b0a79fa9a6a95d