### PR TITLE
Default outputs to summaries and videos folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Video Transcription Summary
 
-This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content. The GUI allows entering one or more video URLs or selecting multiple local audio files (common formats are converted to WAV so Whisper can process them). Each source is transcribed in sequence and written to its own transcript file.
+This project downloads videos, extracts audio, generates transcripts using OpenAI Whisper, and summarizes the content. The GUI allows entering one or more video URLs or selecting multiple local audio files (common formats are converted to WAV so Whisper can process them). Each source is transcribed in sequence and written to its own transcript file. By default, audio downloads and transcripts are saved under the `summaries` folder, while full video downloads go to the `videos` folder.
 
 Audio shorter than 15 minutes is transcribed directly. Longer media is split into equal parts of up to 15 minutes each before transcription, and the resulting text is concatenated.
 
@@ -15,7 +15,8 @@ Audio shorter than 15 minutes is transcribed directly. Longer media is split int
 3. Configure environment variables in a `.env` file:
    ```env
    OPENAI_API_KEY=your_key_here
-   DEFAULT_OUTPUT_DIR=summaries  # Optional custom folder
+   DEFAULT_OUTPUT_DIR=summaries  # Optional custom summaries folder
+   DEFAULT_VIDEO_DIR=videos      # Optional custom video folder
    ```
    The application reads these values using [python-dotenv](https://github.com/theskumar/python-dotenv).
 

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv, set_key
 
 ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
 DEFAULT_OUTPUT_DIR = (Path(__file__).resolve().parent.parent / "summaries").resolve()
+DEFAULT_VIDEO_DIR = (Path(__file__).resolve().parent.parent / "videos").resolve()
 
 # Load existing environment variables from .env if present
 load_dotenv(dotenv_path=ENV_PATH)
@@ -16,6 +17,11 @@ load_dotenv(dotenv_path=ENV_PATH)
 def get_default_output_dir() -> str:
     """Retrieve the default output directory from environment or fallback."""
     return os.getenv("DEFAULT_OUTPUT_DIR", str(DEFAULT_OUTPUT_DIR))
+
+
+def get_default_video_dir() -> str:
+    """Return the default directory for downloaded videos."""
+    return os.getenv("DEFAULT_VIDEO_DIR", str(DEFAULT_VIDEO_DIR))
 
 
 def set_default_output_dir(path: str) -> None:

--- a/src/gui.py
+++ b/src/gui.py
@@ -6,7 +6,7 @@ import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
-from config import get_default_output_dir, set_default_output_dir
+from config import get_default_output_dir, get_default_video_dir, set_default_output_dir
 from process import (
     summarize_transcript,
     transcribe_batch,
@@ -79,7 +79,7 @@ def start_download_video() -> None:
         try:
             paths = download_videos(
                 sources,
-                output_dir_var.get(),
+                get_default_video_dir(),
                 progress_callback=update_progress,
             )
             root.after(0, lambda: transcribe_status_var.set(f"Saved videos: {', '.join(paths)}"))


### PR DESCRIPTION
## Summary
- Add distinct default directories for summaries and downloaded videos
- Save videos to a new `videos` directory and keep audio/transcripts under `summaries`
- Document new `DEFAULT_VIDEO_DIR` env var

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aca43f8c908323aa43ca9639dd9a7d