### PR TITLE
Add script and docs for building Windows executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,20 @@ The `run_gui.bat` script can launch the GUI without manually activating an envir
 3. If Conda is unavailable, it falls back to a local `venv` if one exists.
 
 Double-click `run_gui.bat` in the project folder. The script runs `src\gui.py` with `pythonw`, so no console window appears. If no suitable environment is found, it displays instructions for creating one.
+
+## Building an Executable
+
+Create a standalone Windows build using [PyInstaller](https://pyinstaller.org/):
+
+1. Install PyInstaller:
+   ```bash
+   pip install pyinstaller
+   ```
+2. Run the build script from the project root:
+   ```bat
+   build_gui_exe.bat
+   ```
+   The script bundles `src\gui.py` along with the `.env` file.
+
+The generated `gui.exe` will be located in the `dist` folder.
+

--- a/build_gui_exe.bat
+++ b/build_gui_exe.bat
@@ -1,0 +1,8 @@
+@echo off
+REM Build a standalone Video Transcription Summary GUI executable.
+REM Include the .env file so environment variables are available at runtime.
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%"
+
+pyinstaller --onefile --windowed src\gui.py --add-data ".env;."
+


### PR DESCRIPTION
## Summary
- add build_gui_exe.bat to package the GUI with PyInstaller and include the .env file
- document executable build steps and output location in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca8eb48b08323b34ad616718d8ba9