### PR TITLE
Close CLI window after successful GUI launch

### DIFF
--- a/run_gui.bat
+++ b/run_gui.bat
@@ -16,10 +16,10 @@ REM Try launching with conda run and a named environment.
 where conda >NUL 2>&1
 IF %ERRORLEVEL%==0 (
     cd /d "%SCRIPT_DIR%"
-    CALL conda run -n %CONDA_ENV_NAME% pythonw src\gui.py
-    IF %ERRORLEVEL%==0 GOTO :EOF
-    CALL conda run -n %CONDA_ENV_NAME% python src\gui.py
-    IF %ERRORLEVEL%==0 GOTO :EOF
+    start "" conda run -n %CONDA_ENV_NAME% pythonw src\gui.py
+    IF %ERRORLEVEL%==0 GOTO :ExitSuccess
+    start "" conda run -n %CONDA_ENV_NAME% python src\gui.py
+    IF %ERRORLEVEL%==0 GOTO :ExitSuccess
 )
 
 REM If a local venv exists, activate it.
@@ -36,7 +36,11 @@ echo     python -m venv venv ^&^& pip install -r requirements.txt
 GOTO :PauseFail
 
 :CheckError
-IF %ERRORLEVEL%==0 GOTO :EOF
+IF %ERRORLEVEL%==0 GOTO :ExitSuccess
+GOTO :PauseFail
+
+:ExitSuccess
+exit
 
 :PauseFail
 echo.
@@ -47,8 +51,8 @@ exit /b %ERRORLEVEL%
 :RunWithPython
 where pythonw >NUL 2>&1
 IF %ERRORLEVEL%==0 (
-    pythonw %*
+    start "" pythonw %*
 ) ELSE (
-    python %*
+    start "" python %*
 )
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary
- Launch GUI in separate process and close command window on success
- Show error details in console when GUI start fails

## Testing
- `python -m py_compile src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd79430e88323b92cc1b937c9a13c