### PR TITLE
Add launcher script to run GUI without console window

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The `run_gui.bat` script can launch the GUI without manually activating an envir
 
 Double-click `run_gui.bat` in the project folder. The script runs `src\gui.py` with `pythonw`, so no console window appears. If no suitable environment is found, it displays instructions for creating one.
 
+Alternatively, on Windows you can double-click `start_gui.pyw` to launch the application directly. The `.pyw` extension ensures the GUI runs via `pythonw`, which suppresses the separate Command Prompt window and leaves only the GUI on the task bar.
+
 ## Building an Executable
 
 Create a standalone Windows build using [PyInstaller](https://pyinstaller.org/):

--- a/start_gui.pyw
+++ b/start_gui.pyw
@@ -1,0 +1,14 @@
+"""Launcher for running the GUI without a console window."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the src directory to the Python path so we can import gui
+ROOT = Path(__file__).resolve().parent
+sys.path.append(str(ROOT / "src"))
+
+import gui  # noqa: E402
+
+if __name__ == "__main__":
+    gui.root.mainloop()


### PR DESCRIPTION
## Summary
- Add `start_gui.pyw` launcher to run the Tkinter app without opening a console window.
- Document `.pyw` launcher usage for single-icon behavior on Windows.

## Testing
- `python -m py_compile start_gui.pyw src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68acd8d139c88323911ff81b965af001