### PR TITLE
Handle GUI startup errors with message box

### DIFF
--- a/start_gui.pyw
+++ b/start_gui.pyw
@@ -1,14 +1,35 @@
-"""Launcher for running the GUI without a console window."""
+"""Launcher for running the GUI without a console window.
+
+When executed with ``pythonw`` (e.g. by double‑clicking the file on Windows),
+any import error previously caused the program to exit silently.  This wrapper
+now surfaces such errors to the user via a message box so that they know what
+went wrong.
+"""
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+import tkinter as tk
+from tkinter import messagebox
 
-# Add the src directory to the Python path so we can import gui
+# Add the src directory to the Python path so we can import gui.
 ROOT = Path(__file__).resolve().parent
 sys.path.append(str(ROOT / "src"))
 
-import gui  # noqa: E402
+
+def main() -> None:
+    """Import the GUI module and start the Tkinter event loop."""
+    try:
+        import gui
+    except Exception as exc:  # pragma: no cover - user facing error path
+        root = tk.Tk()
+        root.withdraw()
+        messagebox.showerror("Error", f"Failed to start GUI:\n{exc}")
+        root.destroy()
+        return
+
+    gui.root.mainloop()
+
 
 if __name__ == "__main__":
-    gui.root.mainloop()
+    main()


### PR DESCRIPTION
## Summary
- prevent silent failures when launching GUI by wrapping import in try/except
- show Tk message box with error message if GUI fails to start

## Testing
- `python -m py_compile start_gui.pyw src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68acdbe9e27c83239f4c2daface00ffa