### PR TITLE
Handle missing yt_dlp dependency gracefully

### DIFF
--- a/src/browser_tabs.py
+++ b/src/browser_tabs.py
@@ -5,7 +5,11 @@ import json
 from urllib.error import URLError
 from urllib.request import urlopen
 from urllib.parse import urlparse
-from yt_dlp.extractor import gen_extractors
+
+try:  # pragma: no cover - optional dependency
+    from yt_dlp.extractor import gen_extractors
+except ImportError:  # pragma: no cover - graceful degradation when yt_dlp missing
+    gen_extractors = None  # type: ignore[assignment]
 
 __all__ = [
     "get_chrome_tabs",
@@ -31,6 +35,10 @@ def get_chrome_tabs(port: int = 9222) -> list[str]:
 
 def filter_supported_urls(urls: list[str]) -> list[str]:
     """Filter ``urls`` keeping only those supported by ``yt_dlp`` extractors."""
+    if gen_extractors is None:
+        raise RuntimeError(
+            "yt_dlp is required to detect supported URLs. Install it via 'pip install yt-dlp'."
+        )
     extractors = gen_extractors()
     supported = []
     for url in urls:

--- a/src/gui.py
+++ b/src/gui.py
@@ -68,7 +68,11 @@ def browse_audio_file() -> None:
 
 def load_browser_tabs() -> None:
     """Populate URL list from open Chrome tabs."""
-    urls = get_supported_chrome_tabs()
+    try:
+        urls = get_supported_chrome_tabs()
+    except Exception as exc:  # pragma: no cover - GUI error path
+        messagebox.showerror("Error", str(exc))
+        return
     if urls:
         url_text.delete("1.0", tk.END)
         for url in urls:

--- a/src/process.py
+++ b/src/process.py
@@ -8,7 +8,10 @@ import subprocess
 import tempfile
 import sys
 
-import yt_dlp
+try:  # pragma: no cover - optional dependency
+    import yt_dlp
+except ImportError:  # pragma: no cover - dependency missing
+    yt_dlp = None  # type: ignore[assignment]
 import whisper
 
 # OpenAI is imported lazily to avoid heavy startup cost when the ChatGPT API
@@ -63,6 +66,11 @@ def download_video(
     callers to prefer audio-only downloads or other combinations supported by
     ``yt-dlp``.
     """
+
+    if yt_dlp is None:
+        raise RuntimeError(
+            "yt_dlp is required for video downloads. Install it via 'pip install yt-dlp'."
+        )
 
     if output_dir is None:
         output_dir = get_default_video_dir()
@@ -120,6 +128,11 @@ def download_to_audio(
 ) -> str:
     """Download ``url`` and convert to audio, returning the audio path."""
 
+    if yt_dlp is None:
+        raise RuntimeError(
+            "yt_dlp is required for audio downloads. Install it via 'pip install yt-dlp'."
+        )
+
     if output_dir is None:
         output_dir = get_default_output_dir()
     title_holder = {"title": url}
@@ -170,6 +183,11 @@ def download_videos(
 ) -> list[str]:
     """Download multiple videos sequentially."""
 
+    if yt_dlp is None:
+        raise RuntimeError(
+            "yt_dlp is required for video downloads. Install it via 'pip install yt-dlp'."
+        )
+
     if output_dir is None:
         output_dir = get_default_video_dir()
     videos: list[str] = []
@@ -214,6 +232,11 @@ def convert_to_audio_batch(
     progress_callback=None,
 ) -> list[str]:
     """Download videos and convert them to audio sequentially."""
+
+    if yt_dlp is None:
+        raise RuntimeError(
+            "yt_dlp is required for audio conversion. Install it via 'pip install yt-dlp'."
+        )
 
     if output_dir is None:
         output_dir = get_default_output_dir()


### PR DESCRIPTION
## Summary
- Allow GUI to start when `yt_dlp` is absent by importing it lazily and checking at runtime
- Raise clear errors with installation instructions in processing and browser tab utilities
- Notify GUI users of dependency issues when loading browser tabs

## Testing
- `python -m py_compile start_gui.pyw src/browser_tabs.py src/process.py src/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68acdd7c83748323b40eeeb931d59af7