### PR TITLE
Add batch script to install dependencies

### DIFF
--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -1,0 +1,2 @@
+@echo off
+python -m pip install -r "%~dp0requirements.txt"


### PR DESCRIPTION
## Summary
- add `install_requirements.bat` for Windows to install dependencies from `requirements.txt`

## Testing
- `python -m py_compile $(git ls-files '*.py' '*.pyw')`


------
https://chatgpt.com/codex/tasks/task_e_68ace404dfdc83239f3cd1539f68b146