### PR TITLE
Gracefully handle missing yt-dlp for tab loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ All downloads and transcription actions are logged to a `work.log` file in the p
    ```bash
    pip install -r requirements.txt
    ```
+   The optional [yt-dlp](https://github.com/yt-dlp/yt-dlp) dependency enables the
+   *Load Tabs* feature to detect supported video sites. If it is missing the
+   application will simply return no tabs.
 3. (Optional) Create a `.env` file to store configuration:
    ```env
    OPENAI_API_KEY=your_key_here

--- a/src/browser_tabs.py
+++ b/src/browser_tabs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from urllib.error import URLError
 from urllib.request import urlopen
 from urllib.parse import urlparse
@@ -36,9 +37,12 @@ def get_chrome_tabs(port: int = 9222) -> list[str]:
 def filter_supported_urls(urls: list[str]) -> list[str]:
     """Filter ``urls`` keeping only those supported by ``yt_dlp`` extractors."""
     if gen_extractors is None:
-        raise RuntimeError(
-            "yt_dlp is required to detect supported URLs. Install it via 'pip install yt-dlp'."
+        warnings.warn(
+            "yt_dlp is required to detect supported URLs. Install it via 'pip install yt-dlp'.",
+            RuntimeWarning,
         )
+        return []
+
     extractors = gen_extractors()
     supported = []
     for url in urls:


### PR DESCRIPTION
## Summary
- Avoid hard failures when the optional `yt_dlp` dependency is absent by returning an empty list and warning
- Document the role of optional `yt-dlp` dependency for the Load Tabs feature

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ace724bb2083239557bd89f2519e0e