### PR TITLE
Add pause at end of Windows batch scripts

### DIFF
--- a/git_pull.bat
+++ b/git_pull.bat
@@ -17,7 +17,7 @@ where conda >NUL 2>&1
 IF %ERRORLEVEL%==0 (
     cd /d "%SCRIPT_DIR%"
     CALL conda run -n %CONDA_ENV_NAME% git pull
-    IF %ERRORLEVEL%==0 GOTO :EOF
+    IF %ERRORLEVEL%==0 GOTO :End
 )
 
 REM If a local venv exists, activate it.
@@ -34,10 +34,15 @@ echo     python -m venv venv ^&^& pip install -r requirements.txt
 GOTO :PauseFail
 
 :CheckError
-IF %ERRORLEVEL%==0 GOTO :EOF
+IF %ERRORLEVEL%==0 GOTO :End
 
 :PauseFail
 echo.
 echo Git pull failed. See messages above.
-pause
+GOTO :End
+
+:End
+echo.
+echo 操作完成，按任意键关闭窗口...
+pause >nul
 exit /b %ERRORLEVEL%

--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -1,2 +1,6 @@
 @echo off
 python -m pip install -r "%~dp0requirements.txt"
+echo.
+echo 操作完成，按任意键关闭窗口...
+pause >nul
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary
- ensure `git_pull.bat` waits for a key press before closing so users can review pull results
- add a matching pause to `install_requirements.bat` to keep the window open after dependency installation

## Testing
- `python -m py_compile $(git ls-files '*.py' '*.pyw') && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68aceced4bdc8323923a4084efaa3e8c