### PR TITLE
fix: show Chrome tabs without yt_dlp and translate batch messages

### DIFF
--- a/git_pull.bat
+++ b/git_pull.bat
@@ -43,6 +43,6 @@ GOTO :End
 
 :End
 echo.
-echo 操作完成，按任意键关闭窗口...
+echo Operation completed. Press any key to close the window...
 pause >nul
 exit /b %ERRORLEVEL%

--- a/install_requirements.bat
+++ b/install_requirements.bat
@@ -1,6 +1,6 @@
 @echo off
 python -m pip install -r "%~dp0requirements.txt"
 echo.
-echo 操作完成，按任意键关闭窗口...
+echo Installation complete. Press any key to close the window...
 pause >nul
 exit /b %ERRORLEVEL%

--- a/src/browser_tabs.py
+++ b/src/browser_tabs.py
@@ -41,7 +41,7 @@ def filter_supported_urls(urls: list[str]) -> list[str]:
             "yt_dlp is required to detect supported URLs. Install it via 'pip install yt-dlp'.",
             RuntimeWarning,
         )
-        return []
+        return urls
 
     extractors = gen_extractors()
     supported = []
@@ -57,5 +57,9 @@ def filter_supported_urls(urls: list[str]) -> list[str]:
 
 
 def get_supported_chrome_tabs(port: int = 9222) -> list[str]:
-    """Return URLs of open Chrome tabs supported by ``yt_dlp``."""
+    """Return URLs of open Chrome tabs supported by ``yt_dlp``.
+
+    If ``yt_dlp`` is not installed, all URLs from open tabs are returned
+    without filtering.
+    """
     return filter_supported_urls(get_chrome_tabs(port))


### PR DESCRIPTION
## Summary
- Return all Chrome tab URLs when yt_dlp is missing so remote debugging tabs are detected
- Clarify behavior when yt_dlp isn't installed
- Translate batch script messages to English

## Testing
- `python -m py_compile src/browser_tabs.py`


------
https://chatgpt.com/codex/tasks/task_e_68acef2f61488323ace51e01d54b041a