### PR TITLE
Restore Windows launcher and improve .pyw dependency loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ All downloads and transcription actions are logged to a `work.log` file in the p
 Launch the GUI:
 
 ```bash
-python start_gui.pyw      # Windows (can also double-click)
-python src/gui.py         # any platform
+run_gui.bat              # Windows: auto-detects venv or Conda
+python start_gui.pyw     # Windows: run directly or double-click
+python src/gui.py        # any platform
 ```
+
+The ``start_gui.pyw`` launcher hides the console window. When executed by
+double‑clicking, it attempts to load dependencies from a local ``venv`` folder
+if present. If packages are missing, use ``run_gui.bat`` or install the
+requirements into your default Python environment.
 
 Enter video URLs or select audio files, then run the desired actions to download, transcribe and summarise content.

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,0 +1,58 @@
+@echo off
+REM Launch Video Transcription Summary GUI from a Python environment.
+
+SET SCRIPT_DIR=%~dp0
+SET VENV_DIR=%SCRIPT_DIR%venv
+SET CONDA_ENV_NAME=VTS
+
+REM Try running inside an active Conda environment.
+IF NOT "%CONDA_PREFIX%"=="" (
+    cd /d "%SCRIPT_DIR%"
+    CALL :RunWithPython start_gui.pyw
+    GOTO :CheckError
+)
+
+REM Try launching with conda run and a named environment.
+where conda >NUL 2>&1
+IF %ERRORLEVEL%==0 (
+    cd /d "%SCRIPT_DIR%"
+    start "" conda run -n %CONDA_ENV_NAME% pythonw start_gui.pyw
+    IF %ERRORLEVEL%==0 GOTO :ExitSuccess
+    start "" conda run -n %CONDA_ENV_NAME% python start_gui.pyw
+    IF %ERRORLEVEL%==0 GOTO :ExitSuccess
+)
+
+REM If a local venv exists, activate it.
+IF EXIST "%VENV_DIR%\Scripts\activate.bat" (
+    CALL "%VENV_DIR%\Scripts\activate.bat"
+    cd /d "%SCRIPT_DIR%"
+    CALL :RunWithPython start_gui.pyw
+    GOTO :CheckError
+)
+
+echo No Python environment found.
+echo Install dependencies with Conda (conda create -n %CONDA_ENV_NAME% -f requirements.txt) or:
+echo     python -m venv venv ^&^& pip install -r requirements.txt
+GOTO :PauseFail
+
+:CheckError
+IF %ERRORLEVEL%==0 GOTO :ExitSuccess
+GOTO :PauseFail
+
+:ExitSuccess
+exit
+
+:PauseFail
+echo.
+echo GUI launch failed. See messages above.
+pause
+exit /b %ERRORLEVEL%
+
+:RunWithPython
+where pythonw >NUL 2>&1
+IF %ERRORLEVEL%==0 (
+    start "" pythonw %*
+) ELSE (
+    start "" python %*
+)
+exit /b %ERRORLEVEL%

--- a/start_gui.pyw
+++ b/start_gui.pyw
@@ -16,6 +16,23 @@ from tkinter import messagebox
 ROOT = Path(__file__).resolve().parent
 sys.path.append(str(ROOT / "src"))
 
+# If a bundled virtual environment exists, expose its site-packages so that
+# running this script directly (e.g. via double-click on Windows) can still
+# find required third-party dependencies without needing the environment to be
+# activated first.
+if sys.platform == "win32":
+    venv_site = ROOT / "venv" / "Lib" / "site-packages"
+else:
+    venv_site = (
+        ROOT
+        / "venv"
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+if venv_site.exists():
+    sys.path.insert(0, str(venv_site))
+
 
 def main() -> None:
     """Import the GUI module and start the Tkinter event loop."""


### PR DESCRIPTION
## Summary
- restore `run_gui.bat` Windows launcher that detects Conda or venv environments
- update `start_gui.pyw` to search a local `venv` for dependencies when run directly
- document both launch methods in the README

## Testing
- `python -m py_compile start_gui.pyw`


------
https://chatgpt.com/codex/tasks/task_e_68acf33e9980832392e8ca6ad67f4e55